### PR TITLE
Fix bugs with PKCS5 padding

### DIFF
--- a/Blowfish/src/BlowfishEncoder.mm
+++ b/Blowfish/src/BlowfishEncoder.mm
@@ -35,6 +35,10 @@ unsigned long PKCS5PaddingLength(const unsigned char* data, unsigned long datale
 {
     unsigned char length = 0;
     do {
+        if (datalength == 0)
+        {
+            return 0;
+        }
         if (!data || datalength < 8)
         {
             assert(0);
@@ -56,7 +60,7 @@ unsigned long PKCS5PaddingLength(const unsigned char* data, unsigned long datale
         }
         else
         {
-            assert(0);
+            return 0;
         }
         
     } while (false);


### PR DESCRIPTION
A couple of fixes I needed to make to get PKCS5 padding working properly:
1. Return a padding length of 0 when encrypting data with a length of 0.
2. Return a padding length of 0 when no padding is present.
